### PR TITLE
Fix Bugs in Sampling

### DIFF
--- a/lib/cpp_extension/sample.cpp
+++ b/lib/cpp_extension/sample.cpp
@@ -25,7 +25,7 @@ int64_t load_neighbors_into_buffer(int col_fd, int64_t row_start, int64_t row_co
 
 std::tuple<int64_t*, int64_t*, int64_t> get_new_neighbor_buffer(int64_t row_count){
     int64_t size = (row_count*sizeof(int64_t) + 3*ALIGNMENT)&(long)~(ALIGNMENT-1);
-    int64_t* neighbor_buffer = (int64_t*)malloc(size + ALIGNMENT);
+    int64_t* neighbor_buffer = (int64_t*)malloc(size + 2*ALIGNMENT);
     int64_t* aligned_neighbor_buffer = (int64_t*)(((long)neighbor_buffer+(long)ALIGNMENT)&(long)~(ALIGNMENT-1));
 
     return std::make_tuple(neighbor_buffer, aligned_neighbor_buffer, size/sizeof(int64_t));


### PR DESCRIPTION
This fixes the potential `core dump` during Ginex's sampling. The problem is that the size of `aligned_neighbor_buffer` may be smaller than the `size` in the func `load_neighbors_into_buffer`, which causes out of bounds memory access.